### PR TITLE
fix: correct syntax error in XAdES-EPES signature example

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ const { XMLSerializer } = require("xmldom");
 
 
 const crypto = new Crypto();
-xadesjs.Application.setEngine("NodeJS", );
+xadesjs.Application.setEngine("NodeJS", crypto);
 
 function preparePem(pem) {
     return pem


### PR DESCRIPTION
### Summary

This pull request fixes a small but critical issue in the XAdES-EPES signature code example found in the README. Previously, the call to `xadesjs.Application.setEngine("NodeJS", )` was missing the required `crypto` argument, resulting in invalid JavaScript syntax.

### Changes

- Fixed the function call to correctly pass the `crypto` instance.
- Ensured formatting consistency in the example code.

### Impact

This change ensures that users following the example can run the code successfully in a Node.js environment with `xadesjs` and `@peculiar/webcrypto`.

### Checklist

- [x] Syntax validated
- [x] Example tested for correctness
- [x] Commit message follows conventional format
